### PR TITLE
Change the email field in the profile model to be immutable.

### DIFF
--- a/database_servers/authentication/src/v1/controllers/AuthenticationController/DELETE/deleteAuthentication.js
+++ b/database_servers/authentication/src/v1/controllers/AuthenticationController/DELETE/deleteAuthentication.js
@@ -41,6 +41,7 @@ exports.deleteAuthentication = async (req, res) => {
 
     // Find authentication record by email (which matches the authenticated user)
     const doc = await Authentication.findOne({ _id: id, email });
+    console.log('Authentication record found for deletion:', doc);
     if (!doc) {
       return res.status(404).json({
         status: 'fail',
@@ -51,7 +52,9 @@ exports.deleteAuthentication = async (req, res) => {
     // Use bcrypt to compare hashed password
     const { password } = req.body;
     const passwordMatch = await bcrypt.compare(password, doc.password);
+    console.log('Password match result:', passwordMatch);
     if (!passwordMatch) {
+      console.log('Password mismatch for user:', email);
       return res.status(403).json({
         status: 'fail',
         message: 'Incorrect password.'

--- a/database_servers/profiles/src/v1/controllers/ProfilesController/DELETE/deleteProfile.js
+++ b/database_servers/profiles/src/v1/controllers/ProfilesController/DELETE/deleteProfile.js
@@ -1,6 +1,7 @@
 const Profile = require('../../../models/profile.model');
 
 exports.deleteProfile = async (req, res) => {
+  console.log('Received request to delete profile with params:', req.params);
   try {
     // Verify that the request has come from the authentication server
     // by checking for a custom header set by the authentication proxy
@@ -15,7 +16,9 @@ exports.deleteProfile = async (req, res) => {
     const authId = req.params.id;
     // The id from auth server is the authentication record's ID, stored in depends_on_auth field
     const deletedProfile = await Profile.findOneAndDelete({ depends_on_auth: authId });
+    console.log('Deleted profile result:', deletedProfile);
     if (!deletedProfile) {
+      console.log(`No profile found with authentication ID ${authId} for deletion.`);
       return res.status(404).json({
         status: 'fail',
         message: `No profile found with authentication ID ${authId}.`

--- a/database_servers/profiles/src/v1/models/profile.model.js
+++ b/database_servers/profiles/src/v1/models/profile.model.js
@@ -17,6 +17,7 @@ const accountSchema = new Schema({
     unique: true,
     lowercase: true,
     validate: [isEmail, 'Please enter a valid email address'],
+    immutable: true
   },
   notes: {
     type: String,


### PR DESCRIPTION
The reason for this change was that a user could update the email on record for the profile, but since the Authorization record and the profile are inextricably tied together with IDs, changing the email broke the API's ability to find the profile. Even though the IDs may have matched, the email no longer did, resulting in an error and locking a user out of their account.